### PR TITLE
Pod::Render module

### DIFF
--- a/META.list
+++ b/META.list
@@ -276,3 +276,4 @@ https://raw.githubusercontent.com/masak/007/master/META.info
 https://raw.githubusercontent.com/andydude/p6-c-parser/master/META.info
 https://raw.githubusercontent.com/raydiak/pray/master/META.info
 https://raw.githubusercontent.com/MARTIMM/semaphore-readerswriters/master/META.info
+https://raw.githubusercontent.com/MARTIMM/pod-render/master/META.info


### PR DESCRIPTION
Pod::Render module and pod-render program to render pod to html using Pod::To:HTML and markdown using Pod::To::Markdown. First can also be converted to pdf using wkhtmltopdf when installed. The module is a sort of wrapper to add better css support.